### PR TITLE
fix(e2e): remove ruby as a dependency

### DIFF
--- a/docker/istio-workspace-builder-base.Dockerfile
+++ b/docker/istio-workspace-builder-base.Dockerfile
@@ -10,7 +10,7 @@ ENV CI prow
 
 # Install all dependencies available in RPM repos
 RUN dnf -y update && \
-    dnf -y install bash-completion jq xz golang ruby make wget which inotify-tools podman buildah && \
+    dnf -y install bash-completion jq xz golang make wget which inotify-tools podman buildah && \
     dnf -y clean all
 
 # Go tools


### PR DESCRIPTION
e2e test suite no longer depend on ruby so no need to install it

Related to maistra/istio-workspace#605